### PR TITLE
Improve mobile navigation and footer

### DIFF
--- a/event.js
+++ b/event.js
@@ -1,13 +1,15 @@
-// NAV LINKS - Event Listerner I
-const navLinks = document.querySelectorAll('ul li a');
+// NAV LINKS - Event Listener I
+const navLinks = document.querySelectorAll('#navbar li a');
 navLinks.forEach(link => {
   link.addEventListener('click', function(e) {
-    e.preventDefault(); 
+    e.preventDefault();
     const targetId = this.getAttribute('data-target');
     const targetSection = document.getElementById(targetId);
     if (targetSection) {
       targetSection.scrollIntoView({ behavior: 'smooth' });
     }
+    // close menu on mobile after selection
+    navbar.classList.remove('show');
   });
 });
 
@@ -25,6 +27,13 @@ themeButton.addEventListener("click", changeTheme);
 function changeTheme() {
   document.body.classList.toggle('darkmode');
 }
+
+// HAMBURGER MENU TOGGLE
+const hamburger = document.getElementById('hamburger');
+const navbar = document.getElementById('navbar');
+hamburger.addEventListener('click', () => {
+  navbar.classList.toggle('show');
+});
 
 // TYPEWRITER EFFECT
 const text = 'Welcome to my Page!';

--- a/index.html
+++ b/index.html
@@ -25,8 +25,11 @@
 </head>
 <body>
 
+  <!-- Hamburger Icon for Mobile Nav -->
+  <div id="hamburger">&#9776;</div>
+
   <!-- Nav Bar -->
-  <ul>
+  <ul id="navbar">
     <li id="logo"><img src="download.png" alt="Logo"></li>
     <li><a class="fs" href="#" data-target="home">Home</a></li>
     <li><a href="#" data-target="about">About</a></li>

--- a/styles.css
+++ b/styles.css
@@ -12,7 +12,7 @@ body {
 }
 
 /* NAV BAR */
-ul {
+#navbar {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -24,6 +24,20 @@ ul {
   top: 0;
   width: 100%;
   z-index: 1000;
+}
+
+/* Hamburger icon hidden by default */
+#hamburger {
+  display: none;
+  font-size: 2rem;
+  color: white;
+  background-color: #333;
+  padding: 14px 16px;
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 1001;
+  cursor: pointer;
 }
 
 li {
@@ -349,7 +363,7 @@ input, textarea::placeholder {
 }
 
 /* MOBILE STYLES */
-@media screen and (max-width: 650px) {
+@media screen and (max-width: 768px) {
   /* MAIN IMAGE */
   .Main {
     width: 80%;
@@ -377,22 +391,34 @@ input, textarea::placeholder {
     font-size: 1em;
   }
 
-  /* NAV BAR ADJUSTMENTS */
-  ul {
-    display: flex;
-    flex-direction: row;
+  /* HAMBURGER NAVIGATION */
+  #hamburger {
+    display: block;
+  }
+
+  #navbar {
+    display: none;
+    flex-direction: column;
     align-items: center;
     font-size: medium;
     height: auto;
+    background-color: #333;
   }
 
-  li {
+  #navbar.show {
+    display: flex;
+  }
+
+  #navbar li {
     float: none;
     margin: 5px 0;
+    width: 100%;
   }
 
-  li a {
+  #navbar li a {
     margin-left: 0;
+    text-align: center;
+    width: 100%;
   }
 
   /* THEME BUTTON ADJUSTMENT */
@@ -403,6 +429,18 @@ input, textarea::placeholder {
     white-space: nowrap;
     width: fit-content;
     margin-top: 1.5%;
+  }
+
+  /* Footer should span full width */
+  footer {
+    width: 100vw;
+  }
+
+  /* Allow welcome text to wrap */
+  #welcome {
+    white-space: normal;
+    overflow: visible;
+    word-break: break-word;
   }
 }
 


### PR DESCRIPTION
## Summary
- add hamburger icon markup and use `#navbar` id
- style hamburger and mobile navigation
- ensure footer spans full width on small screens
- allow typing animation text to wrap on mobile
- toggle mobile menu with JavaScript

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6877bf118230832fa99beeb4d0e6e014